### PR TITLE
ci: upgrade to skill-review-and-optimize with /apply-optimize

### DIFF
--- a/.github/workflows/skill-optimize-apply.yml
+++ b/.github/workflows/skill-optimize-apply.yml
@@ -1,0 +1,21 @@
+name: Apply Skill Optimization
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  apply:
+    if: >
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/apply-optimize')
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: tesslio/skill-review-and-optimize@bff9490027d60847df6494fdac7dccfb3ad82948
+        with:
+          mode: apply

--- a/.github/workflows/skill-preview.yml
+++ b/.github/workflows/skill-preview.yml
@@ -1,4 +1,4 @@
-name: Skill Review
+name: Skill Review & Optimize
 on:
   pull_request:
     paths: ['**/SKILL.md']
@@ -10,4 +10,7 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
-      - uses: tesslio/skill-review@22e928dd837202b2b1d1397e0114c92e0fae5ead # main
+      - uses: tesslio/skill-review-and-optimize@bff9490027d60847df6494fdac7dccfb3ad82948
+        with:
+          optimize: true
+          tessl-token: ${{ secrets.TESSL_API_TOKEN }}


### PR DESCRIPTION
Thanks for merging the skill review + improvement PR. Really glad to see the workflow live on the repo! 🙏

Claude-Red already has the Tessl skill review workflow from that last PR. This upgrades it to [`tesslio/skill-review-and-optimize`](https://github.com/tesslio/skill-review-and-optimize), which adds **AI-powered optimization suggestions** and a **one-click `/apply-optimize` trigger** on top of the existing review feedback.

## What's new

| | Before | After |
|---|---|---|
| Action | `tesslio/skill-review` | `tesslio/skill-review-and-optimize` |
| Review scores | ✅ | ✅ |
| AI optimization suggestions | ❌ | ✅ |
| One-click `/apply-optimize` | ❌ | ✅ |

<details>
<summary>How it works</summary>

**On every PR that touches a `SKILL.md`:**
1. The action reviews the changed files and posts scores (same as before)
2. **New:** it also posts an AI-suggested improved version of each skill in the same comment

**To apply the suggestions:**
- Anyone with write access comments `/apply-optimize` on the PR
- The `skill-optimize-apply.yml` workflow commits the improved `SKILL.md` directly to the PR branch. No copy-paste needed

</details>

## 🔑 One-time setup required

Add a `TESSL_API_TOKEN` secret to this repo:
**Settings → Secrets and variables → Actions → New repository secret**

Get a free token at https://tessl.io/account/api-keys.

> Without the token the action still posts review scores and feedback, just without the optimisation suggestions.

## What stays the same

- **Non-blocking by default** - no red CI unless you add `fail-threshold`
- **Only fires on `**/SKILL.md` PRs** - no noise on other changes
- **Contributors need no Tessl account** - only the repo owner needs the API token for optimisation

## Why this matters for Claude-Red

Claude-Red is built around decision-tree methodology, not just command lists, which is exactly what makes these 38 skills genuinely useful in practice. As the library expands into more attack surfaces, maintaining that depth and structure consistently across contributor PRs becomes harder to do manually. This workflow gives you and every contributor an instant quality signal **and** an AI-powered fix. So, the bar that made skills like `offensive-fuzzing` and `offensive-sqli` good stays enforced as the library scales.

---

Since the skill-review action is already running on your PRs. If you ever want to go a step further and auto-optimize skills (not just score them), you can point any agent at [this guide](https://docs.tessl.io/evaluate/optimize-a-skill-using-best-practices) and let it do the heavy lifting.

Ping me - @yogesh-tessl (https://github.com/yogesh-tessl) - if you hit any snags. Thanks!