### PR TITLE
docs(osint): replace inactive EXIF viewer reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `claude-red` are documented here. The library follows a p
 
 ## [Unreleased]
 
+### Changed
+
+- Replaced an inactive EXIF viewer reference in `offensive-osint` with a browser-local metadata viewer and added evidence-corroboration guidance.
+
 ### Planned
 
 - Phase 1 — Internal AD/Windows split (16 skills)

--- a/Skills/recon/offensive-osint/SKILL.md
+++ b/Skills/recon/offensive-osint/SKILL.md
@@ -256,10 +256,12 @@ description: "Comprehensive OSINT methodology skill for offensive security, red 
 - [Forensically](https://29a.ch/photo-forensics/) — Digital image forensics toolkit
 - [ExifTool](https://exiftool.org/) — Read/write/edit metadata
 - [Jimpl](https://jimpl.com/) — Online EXIF viewer
-- [Jeffrey's EXIF viewer](http://exif.regex.info/exif.cgi) — Online metadata viewer
+- [Metadata Viewer](https://metadataremover.ai/metadata-viewer) — Browser-local EXIF, IPTC, XMP, and supported C2PA inspection
 - [FOCA](https://www.elevenpaths.com/labstools/foca) — Metadata in documents
 - [Metagoofil](https://www.edge-security.com/metagoofil.php) — Extract metadata from public documents
 - [C2PA Verify](https://verify.contentauthenticity.org/) — Verify content credentials and AI provenance
+
+Preserve the original artifact and corroborate important metadata values with a second parser before drawing conclusions.
 
 ### Video Analysis
 


### PR DESCRIPTION
## Summary
- replace an inactive EXIF viewer reference in `offensive-osint`
- add a browser-local EXIF/IPTC/XMP/supported-C2PA option
- add original-artifact preservation and second-parser corroboration guidance
- record the existing-skill update in `CHANGELOG.md`

I maintain MetadataRemover.ai. The entry is one option in the existing tool list, and the added caveat explicitly avoids treating any single parser as definitive.

## Verification
- confirmed the removed endpoint returns 404
- confirmed the proposed viewer is publicly accessible
- ran `git diff --check` and a frontmatter/link sanity check