### PR TITLE
Polish README for professional presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,93 +12,57 @@
 [![Stars](https://img.shields.io/github/stars/SnailSploit/claude-red?style=social)](https://github.com/SnailSploit/claude-red)
 [![Forks](https://img.shields.io/github/forks/SnailSploit/claude-red?style=social)](https://github.com/SnailSploit/claude-red/network/members)
 
-Built by **[SnailSploit](https://snailsploit.com)** — GenAI Security Research.
+[Overview](#overview) &bull; [Quickstart](#quickstart) &bull; [Categories](#categories) &bull; [Skill Index](#skill-index) &bull; [Roadmap](#roadmap) &bull; [Contributing](#contributing)
 
 </div>
 
 ---
 
-## Table of Contents
+## Overview
 
-- [What is this](#what-is-this)
-- [Quickstart](#quickstart)
-- [Categories](#categories)
-- [Skill Index](#skill-index)
-  - [Web Application](#web-application)
-  - [Auth & Identity](#auth--identity)
-  - [Active Directory](#active-directory)
-  - [Wireless](#wireless)
-  - [Cloud](#cloud)
-  - [Mobile](#mobile)
-  - [IoT & Embedded](#iot--embedded)
-  - [Infrastructure & Red Team](#infrastructure--red-team)
-  - [Exploit Development](#exploit-development)
-  - [Fuzzing & Vulnerability Research](#fuzzing--vulnerability-research)
-  - [Reconnaissance](#reconnaissance)
-  - [API Security](#api-security)
-  - [Container & Kubernetes](#container--kubernetes)
-  - [CI/CD & Pipeline](#cicd--pipeline)
-  - [Cryptography](#cryptography)
-  - [Privilege Escalation](#privilege-escalation)
-  - [Post-Exploitation](#post-exploitation)
-  - [Forensics & C2](#forensics--c2)
-  - [Supply Chain](#supply-chain)
-  - [Social Engineering](#social-engineering)
-  - [Network Attacks](#network-attacks)
-  - [AI Security](#ai-security)
-  - [Utility](#utility)
-- [Roadmap](#roadmap)
-- [Contributing](#contributing)
-- [License](#license)
-- [Acknowledgements](#acknowledgements)
+`claude-red` is a curated library of offensive security skills for the [Claude Skills system](https://docs.claude.com). Each skill is a structured `SKILL.md` file that primes Claude with expert-level methodology for a specific attack surface — from SQL injection to shellcode, EDR evasion to ADCS abuse.
 
----
+Drop a skill into your Claude environment and it behaves like a domain specialist: it knows the techniques, the tooling, the edge cases, and the escalation paths. Skills load on demand based on conversational triggers — you don't pay context for skills you aren't using.
 
-## What is this
-
-`claude-red` is a curated library of offensive security skills for the [Claude Skills system](https://docs.claude.com). Each skill is a structured `SKILL.md` file that primes Claude with expert-level methodology for a specific attack surface — from SQLi to shellcode, EDR evasion to ADCS abuse.
-
-Drop a skill into your Claude environment and it behaves like a specialist: it knows the techniques, the tooling, the edge cases, and the escalation paths. Skills load on demand based on conversational triggers — you don't pay context for skills you aren't using.
-
-**Use it for:** authorized red team engagements, bug bounty triage, security research, CTF preparation, training operators, and exploring attack surfaces methodically.
+**Use cases:** authorized red team engagements, bug bounty triage, security research, CTF preparation, operator training, and methodical attack surface exploration.
 
 ---
 
 ## Quickstart
 
-### Claude Skills System (recommended)
+### Claude Skills System (Recommended)
 
 ```bash
-# Clone into a directory Claude will scan
 git clone https://github.com/SnailSploit/claude-red ~/.claude/skills/claude-red
+```
 
-# Or install only one category
+Claude auto-loads matching skills based on conversational triggers (e.g., mentioning SQL injection loads `offensive-sqli`).
+
+To install a single category:
+
+```bash
 git clone --filter=blob:none --sparse https://github.com/SnailSploit/claude-red
 cd claude-red && git sparse-checkout set Skills/web Skills/active-directory
 ```
 
-Claude will auto-load matching skills based on conversational triggers (e.g. mentioning SQLi loads `offensive-sqli`).
-
 ### Claude Code
 
 ```bash
-# Point Claude at a single skill before a session
 cat Skills/web/offensive-sqli/SKILL.md | claude --system-file -
 
-# Or load a whole category
 cat Skills/active-directory/**/SKILL.md | claude --system-file -
 ```
 
 ### Claude.ai (Manual)
 
-Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to your conversation.
+Paste the contents of a `SKILL.md` into a Project's system prompt or prepend it to your conversation.
 
 ### Install Script
 
 ```bash
 ./install.sh                           # interactive
 ./install.sh --target ~/.claude/skills # explicit target
-./install.sh --category web            # one category
+./install.sh --category web            # single category
 ```
 
 ---
@@ -107,29 +71,29 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Category | Skills | Focus |
 |---|---:|---|
-| [Web Application](#web-application) | 16 | OWASP Top 10 + business logic + advanced web bug classes |
-| [Auth & Identity](#auth--identity) | 2 | JWT, OAuth |
-| [Active Directory](#active-directory) | 1 | On-prem AD attack methodology *(expanding)* |
-| [Wireless](#wireless) | 13 | 802.11, WPA2/3, EAP, WPS, evil-twin, BLE, Zigbee, Z-Wave, LoRa, sub-GHz |
-| [Cloud](#cloud) | 1 | AWS / Azure / GCP attack paths *(expanding)* |
-| [Mobile](#mobile) | 1 | Android + iOS pentest *(expanding)* |
-| [IoT & Embedded](#iot--embedded) | 1 | Hardware, firmware, RTOS, ICS *(expanding)* |
-| [Infrastructure & Red Team](#infrastructure--red-team) | 7 | Initial access, EDR evasion, advanced red team ops, Windows internals |
-| [Exploit Development](#exploit-development) | 6 | Stack/heap, mitigations, crash analysis, TOCTOU |
-| [Fuzzing & VR](#fuzzing--vulnerability-research) | 4 | libFuzzer, AFL++, bug ID, vuln classes |
-| [Reconnaissance](#reconnaissance) | 2 | OSINT tooling and methodology |
+| [Web Application](#web-application) | 16 | OWASP Top 10, business logic, advanced web vulnerability classes |
+| [Auth & Identity](#auth--identity) | 2 | JWT exploitation, OAuth/OIDC abuse |
+| [Active Directory](#active-directory) | 1 | On-prem AD attack methodology |
+| [Wireless](#wireless) | 14 | 802.11, WPA2/3, EAP, WPS, evil-twin, BLE, Zigbee, Z-Wave, LoRa, sub-GHz |
+| [Cloud](#cloud) | 1 | AWS, Azure, GCP attack paths |
+| [Mobile](#mobile) | 1 | Android and iOS application testing |
+| [IoT & Embedded](#iot--embedded) | 1 | Hardware, firmware, RTOS, ICS/OT |
+| [Infrastructure & Red Team](#infrastructure--red-team) | 7 | Initial access, EDR evasion, advanced red team operations, Windows internals |
+| [Exploit Development](#exploit-development) | 6 | Stack/heap corruption, ROP, mitigations, crash analysis, TOCTOU |
+| [Fuzzing & Vulnerability Research](#fuzzing--vulnerability-research) | 4 | libFuzzer, AFL++, coverage-guided fuzzing, vulnerability taxonomy |
+| [Reconnaissance](#reconnaissance) | 2 | OSINT tooling and structured intelligence collection |
 | [API Security](#api-security) | 2 | REST/gRPC/WebSocket testing, business logic abuse |
-| [Container & Kubernetes](#container--kubernetes) | 2 | Container escape, K8s cluster attacks |
+| [Container & Kubernetes](#container--kubernetes) | 2 | Container escape, Kubernetes cluster exploitation |
 | [CI/CD & Pipeline](#cicd--pipeline) | 2 | Pipeline exploitation, secrets extraction |
-| [Cryptography](#cryptography) | 2 | Crypto implementation attacks, TLS/SSL |
-| [Privilege Escalation](#privilege-escalation) | 2 | Linux and Windows privesc |
-| [Post-Exploitation](#post-exploitation) | 3 | Lateral movement, persistence, data exfiltration |
-| [Forensics & C2](#forensics--c2) | 2 | Anti-forensics, C2 framework tradecraft |
+| [Cryptography](#cryptography) | 2 | Cryptographic implementation attacks, TLS/SSL |
+| [Privilege Escalation](#privilege-escalation) | 2 | Linux and Windows privilege escalation |
+| [Post-Exploitation](#post-exploitation) | 3 | Lateral movement, persistence mechanisms, data exfiltration |
+| [Forensics & C2](#forensics--c2) | 2 | Anti-forensics tradecraft, C2 framework operations |
 | [Supply Chain](#supply-chain) | 2 | Supply chain attacks, dependency confusion |
 | [Social Engineering](#social-engineering) | 2 | Phishing campaigns, physical/vishing/smishing |
-| [Network Attacks](#network-attacks) | 1 | Layer 2/3 attacks, MITM, poisoning |
-| [AI Security](#ai-security) | 1 | Prompt injection, jailbreaks, RAG poisoning |
-| [Utility](#utility) | 2 | Fast-checking, professional reporting |
+| [Network Attacks](#network-attacks) | 1 | Layer 2/3 attacks, MITM, protocol poisoning |
+| [AI Security](#ai-security) | 1 | Prompt injection, jailbreaking, RAG poisoning |
+| [Utility](#utility) | 2 | Fast triage checklists, professional reporting |
 
 ---
 
@@ -141,22 +105,22 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-sqli`](Skills/web/offensive-sqli/SKILL.md) | SQL injection — error/blind/OOB, DB-specific, ORM CVEs, cloud paths |
-| [`offensive-xss`](Skills/web/offensive-xss/SKILL.md) | Cross-site scripting — stored, reflected, DOM, mutation |
-| [`offensive-ssrf`](Skills/web/offensive-ssrf/SKILL.md) | Server-side request forgery — cloud metadata, filter bypass |
-| [`offensive-ssti`](Skills/web/offensive-ssti/SKILL.md) | Server-side template injection — engine ID, RCE paths |
-| [`offensive-xxe`](Skills/web/offensive-xxe/SKILL.md) | XML external entity — OOB exfil, blind exploitation |
-| [`offensive-idor`](Skills/web/offensive-idor/SKILL.md) | Insecure direct object references — enumeration, business logic |
-| [`offensive-file-upload`](Skills/web/offensive-file-upload/SKILL.md) | File upload — extension bypass, polyglots, webshells |
-| [`offensive-rce`](Skills/web/offensive-rce/SKILL.md) | Remote code execution — chaining, command injection |
-| [`offensive-deserialization`](Skills/web/offensive-deserialization/SKILL.md) | Insecure deserialization — Java/PHP/.NET gadget chains |
-| [`offensive-race-condition`](Skills/web/offensive-race-condition/SKILL.md) | Race conditions — TOCTOU, single-packet, limit bypass |
-| [`offensive-request-smuggling`](Skills/web/offensive-request-smuggling/SKILL.md) | HTTP request smuggling — CL.TE, TE.CL, h2 desync |
-| [`offensive-open-redirect`](Skills/web/offensive-open-redirect/SKILL.md) | Open redirect — OAuth abuse, phishing, SSRF pivots |
+| [`offensive-sqli`](Skills/web/offensive-sqli/SKILL.md) | SQL injection — error-based, blind, OOB, DB-specific payloads, ORM CVEs |
+| [`offensive-xss`](Skills/web/offensive-xss/SKILL.md) | Cross-site scripting — stored, reflected, DOM-based, mutation XSS |
+| [`offensive-ssrf`](Skills/web/offensive-ssrf/SKILL.md) | Server-side request forgery — cloud metadata pivots, filter bypass |
+| [`offensive-ssti`](Skills/web/offensive-ssti/SKILL.md) | Server-side template injection — engine fingerprinting, RCE chains |
+| [`offensive-xxe`](Skills/web/offensive-xxe/SKILL.md) | XML external entity — OOB exfiltration, blind XXE techniques |
+| [`offensive-idor`](Skills/web/offensive-idor/SKILL.md) | Insecure direct object references — enumeration, authorization bypass |
+| [`offensive-file-upload`](Skills/web/offensive-file-upload/SKILL.md) | File upload — extension bypass, polyglot files, webshell deployment |
+| [`offensive-rce`](Skills/web/offensive-rce/SKILL.md) | Remote code execution — command injection, deserialization chains |
+| [`offensive-deserialization`](Skills/web/offensive-deserialization/SKILL.md) | Insecure deserialization — Java, PHP, .NET gadget chains |
+| [`offensive-race-condition`](Skills/web/offensive-race-condition/SKILL.md) | Race conditions — TOCTOU, single-packet attacks, limit bypass |
+| [`offensive-request-smuggling`](Skills/web/offensive-request-smuggling/SKILL.md) | HTTP request smuggling — CL.TE, TE.CL, H2 desync |
+| [`offensive-open-redirect`](Skills/web/offensive-open-redirect/SKILL.md) | Open redirect — OAuth token theft, phishing, SSRF pivots |
 | [`offensive-parameter-pollution`](Skills/web/offensive-parameter-pollution/SKILL.md) | HTTP parameter pollution — WAF bypass, logic confusion |
-| [`offensive-graphql`](Skills/web/offensive-graphql/SKILL.md) | GraphQL — introspection, batching, IDOR via aliases |
-| [`offensive-waf-bypass`](Skills/web/offensive-waf-bypass/SKILL.md) | WAF bypass — encoding, chunking, case mutation |
-| [`offensive-business-logic`](Skills/web/offensive-business-logic/SKILL.md) | Business logic — workflow bypass, pricing, refunds, chains |
+| [`offensive-graphql`](Skills/web/offensive-graphql/SKILL.md) | GraphQL — introspection abuse, batching attacks, alias-based IDOR |
+| [`offensive-waf-bypass`](Skills/web/offensive-waf-bypass/SKILL.md) | WAF bypass — encoding tricks, chunked transfer, case mutation |
+| [`offensive-business-logic`](Skills/web/offensive-business-logic/SKILL.md) | Business logic — workflow bypass, pricing abuse, multi-step chains |
 
 ### Auth & Identity
 
@@ -164,8 +128,8 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-jwt`](Skills/auth/offensive-jwt/SKILL.md) | JWT — alg:none, key confusion, secret cracking |
-| [`offensive-oauth`](Skills/auth/offensive-oauth/SKILL.md) | OAuth — open redirect abuse, token leakage, PKCE bypass |
+| [`offensive-jwt`](Skills/auth/offensive-jwt/SKILL.md) | JWT attacks — alg:none, key confusion, secret cracking, claim tampering |
+| [`offensive-oauth`](Skills/auth/offensive-oauth/SKILL.md) | OAuth/OIDC — redirect URI abuse, token leakage, PKCE bypass |
 
 ### Active Directory
 
@@ -173,9 +137,7 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-active-directory`](Skills/active-directory/offensive-active-directory/SKILL.md) | AD — Kerberoast, ASREProast, ACL abuse, ADCS ESC1-15, delegation, persistence, hybrid AAD |
-
-> **Note:** This category is being expanded. The AD overview is being split into 16 focused skills (Kerberoasting, ASREProasting, ADCS, coercion, NTLM relay, BloodHound, ticket forgery, GPO abuse, etc.). See [Roadmap](#roadmap).
+| [`offensive-active-directory`](Skills/active-directory/offensive-active-directory/SKILL.md) | AD methodology — Kerberoast, ASREProast, ACL abuse, ADCS ESC1-15, delegation, hybrid AAD |
 
 ### Wireless
 
@@ -183,20 +145,20 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-wifi`](Skills/wireless/offensive-wifi/SKILL.md) | 802.11 overview — entrypoint into the wireless category |
-| [`offensive-wifi-recon`](Skills/wireless/offensive-wifi-recon/SKILL.md) | Adapter selection, monitor mode, multi-band airspace mapping |
-| [`offensive-wpa2-psk`](Skills/wireless/offensive-wpa2-psk/SKILL.md) | Handshake capture, PMKID, hashcat 22000 cracking |
-| [`offensive-wpa3-sae`](Skills/wireless/offensive-wpa3-sae/SKILL.md) | Transition-mode downgrade, Dragonblood, SAE side-channels |
-| [`offensive-wpa-enterprise`](Skills/wireless/offensive-wpa-enterprise/SKILL.md) | 802.1X / EAP attacks, eaphammer evil-twin RADIUS |
-| [`offensive-wps`](Skills/wireless/offensive-wps/SKILL.md) | Pixie Dust, online PIN brute, vendor PIN generators |
-| [`offensive-evil-twin`](Skills/wireless/offensive-evil-twin/SKILL.md) | KARMA, Mana, captive portal, post-association MITM |
-| [`offensive-krack-fragattacks`](Skills/wireless/offensive-krack-fragattacks/SKILL.md) | KRACK + FragAttacks supplicant testing |
-| [`offensive-deauth-disassoc`](Skills/wireless/offensive-deauth-disassoc/SKILL.md) | Targeted/broadcast deauth, PMF awareness, action frames |
-| [`offensive-bluetooth-ble`](Skills/wireless/offensive-bluetooth-ble/SKILL.md) | BLE GATT enum, pairing downgrade, sniffing, MITM |
-| [`offensive-bluetooth-classic`](Skills/wireless/offensive-bluetooth-classic/SKILL.md) | BR/EDR — SDP, SPP, KNOB, BlueBorne, HID spoofing |
-| [`offensive-zigbee-thread-matter`](Skills/wireless/offensive-zigbee-thread-matter/SKILL.md) | 802.15.4 mesh — KillerBee, Touchlink abuse, ZCL command injection |
-| [`offensive-z-wave`](Skills/wireless/offensive-z-wave/SKILL.md) | S0 key derivation flaw, S2 commissioning, hub pivots |
-| [`offensive-lorawan-sub-ghz`](Skills/wireless/offensive-lorawan-sub-ghz/SKILL.md) | LoRaWAN ABP/OTAA, KeeLoq garage doors, fixed-code, TPMS |
+| [`offensive-wifi`](Skills/wireless/offensive-wifi/SKILL.md) | 802.11 overview — entrypoint for wireless assessments |
+| [`offensive-wifi-recon`](Skills/wireless/offensive-wifi-recon/SKILL.md) | Adapter configuration, monitor mode, multi-band airspace mapping |
+| [`offensive-wpa2-psk`](Skills/wireless/offensive-wpa2-psk/SKILL.md) | WPA2-PSK — handshake capture, PMKID extraction, hashcat cracking |
+| [`offensive-wpa3-sae`](Skills/wireless/offensive-wpa3-sae/SKILL.md) | WPA3-SAE — transition-mode downgrade, Dragonblood, side-channel attacks |
+| [`offensive-wpa-enterprise`](Skills/wireless/offensive-wpa-enterprise/SKILL.md) | 802.1X/EAP — credential relay, evil-twin RADIUS, certificate abuse |
+| [`offensive-wps`](Skills/wireless/offensive-wps/SKILL.md) | WPS — Pixie Dust offline attack, online PIN brute force, vendor PIN prediction |
+| [`offensive-evil-twin`](Skills/wireless/offensive-evil-twin/SKILL.md) | Evil twin — KARMA, Mana, captive portal credential capture, MITM |
+| [`offensive-krack-fragattacks`](Skills/wireless/offensive-krack-fragattacks/SKILL.md) | KRACK and FragAttacks — supplicant vulnerability testing |
+| [`offensive-deauth-disassoc`](Skills/wireless/offensive-deauth-disassoc/SKILL.md) | Deauthentication — targeted/broadcast frames, PMF awareness |
+| [`offensive-bluetooth-ble`](Skills/wireless/offensive-bluetooth-ble/SKILL.md) | Bluetooth LE — GATT enumeration, pairing downgrade, sniffing, MITM |
+| [`offensive-bluetooth-classic`](Skills/wireless/offensive-bluetooth-classic/SKILL.md) | Bluetooth BR/EDR — SDP probing, KNOB attack, BlueBorne, HID spoofing |
+| [`offensive-zigbee-thread-matter`](Skills/wireless/offensive-zigbee-thread-matter/SKILL.md) | 802.15.4 mesh — KillerBee, Touchlink commissioning abuse, ZCL injection |
+| [`offensive-z-wave`](Skills/wireless/offensive-z-wave/SKILL.md) | Z-Wave — S0 key derivation, S2 commissioning attacks, hub pivots |
+| [`offensive-lorawan-sub-ghz`](Skills/wireless/offensive-lorawan-sub-ghz/SKILL.md) | LoRaWAN and sub-GHz — ABP/OTAA attacks, KeeLoq, fixed-code replay, TPMS |
 
 ### Cloud
 
@@ -204,9 +166,7 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-cloud`](Skills/cloud/offensive-cloud/SKILL.md) | AWS / Azure / GCP — privesc, IMDS, cross-account, persistence, CSPM evasion |
-
-> **Note:** Cloud-identity (Entra/AAD/Okta hybrid) skills coming separately. See [Roadmap](#roadmap).
+| [`offensive-cloud`](Skills/cloud/offensive-cloud/SKILL.md) | Multi-cloud — privilege escalation, IMDS abuse, cross-account pivots, CSPM evasion |
 
 ### Mobile
 
@@ -214,7 +174,7 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-mobile`](Skills/mobile/offensive-mobile/SKILL.md) | Android + iOS — Frida, pinning, storage, biometric, deep links |
+| [`offensive-mobile`](Skills/mobile/offensive-mobile/SKILL.md) | Android and iOS — Frida hooking, certificate pinning bypass, storage, biometric flaws |
 
 ### IoT & Embedded
 
@@ -222,9 +182,7 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-iot`](Skills/iot/offensive-iot/SKILL.md) | Hardware recon, firmware, RTOS, ICS/OT, MQTT/CoAP |
-
-> **Note:** Being split into 10 focused skills (UART/JTAG, flash dump, fault injection, U-Boot, secure boot, RTOS, ICS protocols). See [Roadmap](#roadmap).
+| [`offensive-iot`](Skills/iot/offensive-iot/SKILL.md) | IoT/OT — hardware interfaces, firmware extraction, RTOS, ICS protocols, MQTT/CoAP |
 
 ### Infrastructure & Red Team
 
@@ -232,13 +190,13 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-initial-access`](Skills/infrastructure/offensive-initial-access/SKILL.md) | Phishing, drive-by, supply chain — TA0001 |
-| [`offensive-advanced-redteam`](Skills/infrastructure/offensive-advanced-redteam/SKILL.md) | Full kill chain, C2, OPSEC, lateral, persistence |
-| [`offensive-edr-evasion`](Skills/infrastructure/offensive-edr-evasion/SKILL.md) | Unhooking, indirect syscalls, PPID spoofing |
-| [`offensive-shellcode`](Skills/infrastructure/offensive-shellcode/SKILL.md) | Writing, encoding, injection techniques |
-| [`offensive-keylogger-arch`](Skills/infrastructure/offensive-keylogger-arch/SKILL.md) | Keylogger architecture and input-capture techniques |
-| [`offensive-windows-mitigations`](Skills/infrastructure/offensive-windows-mitigations/SKILL.md) | Windows mitigations — ACG, Arbitrary Code Guard |
-| [`offensive-windows-boundaries`](Skills/infrastructure/offensive-windows-boundaries/SKILL.md) | Defeating Windows boundaries — sandbox escape, privilege |
+| [`offensive-initial-access`](Skills/infrastructure/offensive-initial-access/SKILL.md) | Initial access — phishing payloads, drive-by delivery, supply chain vectors (TA0001) |
+| [`offensive-advanced-redteam`](Skills/infrastructure/offensive-advanced-redteam/SKILL.md) | Full kill chain — C2 infrastructure, OPSEC, lateral movement, persistence |
+| [`offensive-edr-evasion`](Skills/infrastructure/offensive-edr-evasion/SKILL.md) | EDR evasion — userland unhooking, indirect syscalls, PPID spoofing |
+| [`offensive-shellcode`](Skills/infrastructure/offensive-shellcode/SKILL.md) | Shellcode — writing, encoding, injection techniques, position-independent code |
+| [`offensive-keylogger-arch`](Skills/infrastructure/offensive-keylogger-arch/SKILL.md) | Input capture — keylogger architecture, hooking mechanisms |
+| [`offensive-windows-mitigations`](Skills/infrastructure/offensive-windows-mitigations/SKILL.md) | Windows mitigations — ACG, CIG, CFG, CET bypass techniques |
+| [`offensive-windows-boundaries`](Skills/infrastructure/offensive-windows-boundaries/SKILL.md) | Windows boundary defeat — sandbox escape, integrity level bypass |
 
 ### Exploit Development
 
@@ -246,12 +204,12 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-exploit-development`](Skills/exploit-dev/offensive-exploit-development/SKILL.md) | Stack/heap, ROP chains, mitigations |
-| [`offensive-exploit-dev-course`](Skills/exploit-dev/offensive-exploit-dev-course/SKILL.md) | Structured curriculum format |
-| [`offensive-basic-exploitation`](Skills/exploit-dev/offensive-basic-exploitation/SKILL.md) | Linux exploitation, mitigations disabled — beginner-to-mid |
-| [`offensive-crash-analysis`](Skills/exploit-dev/offensive-crash-analysis/SKILL.md) | Crash triage, exploitability assessment, root cause |
-| [`offensive-mitigations`](Skills/exploit-dev/offensive-mitigations/SKILL.md) | Modern kernel mitigations — ASLR, CFG, CET, PAC |
-| [`offensive-toctou`](Skills/exploit-dev/offensive-toctou/SKILL.md) | Time-of-check/use across binary, kernel, web, container |
+| [`offensive-exploit-development`](Skills/exploit-dev/offensive-exploit-development/SKILL.md) | Exploit development — stack/heap corruption, ROP chains, mitigation bypass |
+| [`offensive-exploit-dev-course`](Skills/exploit-dev/offensive-exploit-dev-course/SKILL.md) | Structured exploit development curriculum |
+| [`offensive-basic-exploitation`](Skills/exploit-dev/offensive-basic-exploitation/SKILL.md) | Linux binary exploitation — beginner to intermediate, mitigations disabled |
+| [`offensive-crash-analysis`](Skills/exploit-dev/offensive-crash-analysis/SKILL.md) | Crash triage — exploitability assessment, root-cause analysis |
+| [`offensive-mitigations`](Skills/exploit-dev/offensive-mitigations/SKILL.md) | Modern mitigations — ASLR, CFG, CET, PAC analysis and bypass |
+| [`offensive-toctou`](Skills/exploit-dev/offensive-toctou/SKILL.md) | TOCTOU race conditions — binary, kernel, web, and container contexts |
 
 ### Fuzzing & Vulnerability Research
 
@@ -259,10 +217,10 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-fuzzing`](Skills/fuzzing/offensive-fuzzing/SKILL.md) | libFuzzer, AFL++, coverage-guided, mutation strategies |
-| [`offensive-fuzzing-course`](Skills/fuzzing/offensive-fuzzing-course/SKILL.md) | Curriculum — finding vulns via fuzzing |
-| [`offensive-bug-identification`](Skills/fuzzing/offensive-bug-identification/SKILL.md) | Code review patterns, static analysis triggers |
-| [`offensive-vuln-classes`](Skills/fuzzing/offensive-vuln-classes/SKILL.md) | Vulnerability classes — real-world examples, taxonomy |
+| [`offensive-fuzzing`](Skills/fuzzing/offensive-fuzzing/SKILL.md) | Fuzzing — libFuzzer, AFL++, coverage-guided strategies, mutation engines |
+| [`offensive-fuzzing-course`](Skills/fuzzing/offensive-fuzzing-course/SKILL.md) | Vulnerability discovery through fuzzing — structured curriculum |
+| [`offensive-bug-identification`](Skills/fuzzing/offensive-bug-identification/SKILL.md) | Bug identification — code review patterns, static analysis triggers |
+| [`offensive-vuln-classes`](Skills/fuzzing/offensive-vuln-classes/SKILL.md) | Vulnerability taxonomy — real-world examples, classification frameworks |
 
 ### Reconnaissance
 
@@ -270,8 +228,8 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-osint`](Skills/recon/offensive-osint/SKILL.md) | OSINT tools — recon-ng, theHarvester, Maltego pipelines |
-| [`offensive-osint-methodology`](Skills/recon/offensive-osint-methodology/SKILL.md) | OSINT methodology — structured intelligence collection |
+| [`offensive-osint`](Skills/recon/offensive-osint/SKILL.md) | OSINT tooling — recon-ng, theHarvester, Maltego, Spiderfoot |
+| [`offensive-osint-methodology`](Skills/recon/offensive-osint-methodology/SKILL.md) | OSINT methodology — structured intelligence collection and analysis |
 
 ### API Security
 
@@ -279,8 +237,8 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-api-security`](Skills/api/offensive-api-security/SKILL.md) | API testing — OWASP API Top 10, REST/gRPC/WebSocket, BOLA, BFLA, mass assignment |
-| [`offensive-api-abuse`](Skills/api/offensive-api-abuse/SKILL.md) | API business logic — chaining, batching, JWT manipulation, webhook hijacking |
+| [`offensive-api-security`](Skills/api/offensive-api-security/SKILL.md) | API testing — OWASP API Top 10, BOLA, BFLA, mass assignment, rate limiting |
+| [`offensive-api-abuse`](Skills/api/offensive-api-abuse/SKILL.md) | API business logic — endpoint chaining, batching abuse, webhook hijacking |
 
 ### Container & Kubernetes
 
@@ -288,8 +246,8 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-container-escape`](Skills/container/offensive-container-escape/SKILL.md) | Container breakout — privileged escape, Docker socket, capabilities, cgroup, runc CVEs |
-| [`offensive-k8s-attacks`](Skills/container/offensive-k8s-attacks/SKILL.md) | Kubernetes — RBAC abuse, etcd access, kubelet API, pod escape, secrets, CRD exploitation |
+| [`offensive-container-escape`](Skills/container/offensive-container-escape/SKILL.md) | Container breakout — privileged mode, Docker socket, capabilities, runc CVEs |
+| [`offensive-k8s-attacks`](Skills/container/offensive-k8s-attacks/SKILL.md) | Kubernetes attacks — RBAC abuse, etcd access, kubelet API, pod escape, CRD exploitation |
 
 ### CI/CD & Pipeline
 
@@ -297,8 +255,8 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-cicd-pipeline`](Skills/cicd/offensive-cicd-pipeline/SKILL.md) | CI/CD exploitation — GitHub Actions injection, Jenkins RCE, GitLab CI, Azure DevOps |
-| [`offensive-cicd-secrets`](Skills/cicd/offensive-cicd-secrets/SKILL.md) | CI/CD secrets — env var extraction, vault misconfigs, OIDC federation, runner token abuse |
+| [`offensive-cicd-pipeline`](Skills/cicd/offensive-cicd-pipeline/SKILL.md) | CI/CD exploitation — GitHub Actions injection, Jenkins RCE, GitLab CI abuse |
+| [`offensive-cicd-secrets`](Skills/cicd/offensive-cicd-secrets/SKILL.md) | CI/CD secrets — environment variable extraction, vault misconfigs, runner token abuse |
 
 ### Cryptography
 
@@ -306,8 +264,8 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-crypto-attacks`](Skills/crypto/offensive-crypto-attacks/SKILL.md) | Crypto attacks — padding oracle, ECB manipulation, hash extension, RSA, weak PRNG |
-| [`offensive-tls-attacks`](Skills/crypto/offensive-tls-attacks/SKILL.md) | TLS/SSL — POODLE, DROWN, Heartbleed, pinning bypass, HSTS bypass, 0-RTT replay |
+| [`offensive-crypto-attacks`](Skills/crypto/offensive-crypto-attacks/SKILL.md) | Cryptographic attacks — padding oracle, ECB manipulation, hash extension, weak PRNG |
+| [`offensive-tls-attacks`](Skills/crypto/offensive-tls-attacks/SKILL.md) | TLS/SSL attacks — POODLE, DROWN, Heartbleed, pinning bypass, 0-RTT replay |
 
 ### Privilege Escalation
 
@@ -315,8 +273,8 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-linux-privesc`](Skills/privesc/offensive-linux-privesc/SKILL.md) | Linux privesc — SUID, capabilities, sudo, cron, kernel exploits, Docker group |
-| [`offensive-windows-privesc`](Skills/privesc/offensive-windows-privesc/SKILL.md) | Windows privesc — Potato family, service misconfigs, DLL hijacking, UAC bypass, PrintNightmare |
+| [`offensive-linux-privesc`](Skills/privesc/offensive-linux-privesc/SKILL.md) | Linux privilege escalation — SUID, capabilities, sudo, cron, kernel exploits |
+| [`offensive-windows-privesc`](Skills/privesc/offensive-windows-privesc/SKILL.md) | Windows privilege escalation — Potato family, service misconfigs, DLL hijacking, UAC bypass |
 
 ### Post-Exploitation
 
@@ -324,9 +282,9 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-lateral-movement`](Skills/post-exploitation/offensive-lateral-movement/SKILL.md) | Lateral movement — PTH, PTT, NTLM relay, WMI/WinRM/DCOM, tunneling (chisel, ligolo-ng) |
-| [`offensive-persistence`](Skills/post-exploitation/offensive-persistence/SKILL.md) | Persistence — registry, scheduled tasks, WMI subs, Golden/Silver tickets, PAM backdoors |
-| [`offensive-data-exfiltration`](Skills/post-exploitation/offensive-data-exfiltration/SKILL.md) | Data exfiltration — DNS/HTTPS/ICMP tunneling, cloud dead drops, steganography |
+| [`offensive-lateral-movement`](Skills/post-exploitation/offensive-lateral-movement/SKILL.md) | Lateral movement — PTH, PTT, NTLM relay, WMI/WinRM/DCOM, tunneling |
+| [`offensive-persistence`](Skills/post-exploitation/offensive-persistence/SKILL.md) | Persistence — registry, scheduled tasks, WMI subscriptions, ticket forgery, PAM backdoors |
+| [`offensive-data-exfiltration`](Skills/post-exploitation/offensive-data-exfiltration/SKILL.md) | Data exfiltration — DNS/HTTPS/ICMP tunneling, cloud staging, steganography |
 
 ### Forensics & C2
 
@@ -334,8 +292,8 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-anti-forensics`](Skills/forensics/offensive-anti-forensics/SKILL.md) | Anti-forensics — log clearing, timestomping, ADS hiding, memory cleanup, anti-VM |
-| [`offensive-c2-frameworks`](Skills/forensics/offensive-c2-frameworks/SKILL.md) | C2 tradecraft — Cobalt Strike, Sliver, Mythic, Havoc, Metasploit, redirectors, domain fronting |
+| [`offensive-anti-forensics`](Skills/forensics/offensive-anti-forensics/SKILL.md) | Anti-forensics — log manipulation, timestomping, ADS abuse, memory cleanup |
+| [`offensive-c2-frameworks`](Skills/forensics/offensive-c2-frameworks/SKILL.md) | C2 tradecraft — Cobalt Strike, Sliver, Mythic, Havoc, redirectors, domain fronting |
 
 ### Supply Chain
 
@@ -343,8 +301,8 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-supply-chain`](Skills/supply-chain/offensive-supply-chain/SKILL.md) | Supply chain — dependency confusion, typosquatting, build system attacks, image trojaning |
-| [`offensive-dependency-confusion`](Skills/supply-chain/offensive-dependency-confusion/SKILL.md) | Dependency confusion — npm/PyPI/NuGet/Maven/Go namespace attacks, safe PoC methodology |
+| [`offensive-supply-chain`](Skills/supply-chain/offensive-supply-chain/SKILL.md) | Supply chain attacks — dependency confusion, typosquatting, build system compromise |
+| [`offensive-dependency-confusion`](Skills/supply-chain/offensive-dependency-confusion/SKILL.md) | Dependency confusion — npm/PyPI/NuGet/Maven namespace attacks, safe PoC methodology |
 
 ### Social Engineering
 
@@ -352,8 +310,8 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-phishing`](Skills/social-engineering/offensive-phishing/SKILL.md) | Phishing — GoPhish, EvilGinx2, payload delivery, email auth bypass, MFA phishing |
-| [`offensive-social-engineering`](Skills/social-engineering/offensive-social-engineering/SKILL.md) | Social engineering — pretexting, vishing, smishing, physical SE, USB drops, watering holes |
+| [`offensive-phishing`](Skills/social-engineering/offensive-phishing/SKILL.md) | Phishing — GoPhish, EvilGinx2, payload delivery, email authentication bypass |
+| [`offensive-social-engineering`](Skills/social-engineering/offensive-social-engineering/SKILL.md) | Social engineering — pretexting, vishing, smishing, physical SE, USB drops |
 
 ### Network Attacks
 
@@ -361,7 +319,7 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-network-attacks`](Skills/network/offensive-network-attacks/SKILL.md) | Network L2/L3 — ARP spoofing, LLMNR/NBT-NS poisoning, VLAN hopping, IPv6 attacks, MITM |
+| [`offensive-network-attacks`](Skills/network/offensive-network-attacks/SKILL.md) | Network layer attacks — ARP spoofing, LLMNR/NBT-NS poisoning, VLAN hopping, MITM |
 
 ### AI Security
 
@@ -369,7 +327,7 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-ai-security`](Skills/ai/offensive-ai-security/SKILL.md) | AI pentest — prompt injection, jailbreaking, RAG poisoning |
+| [`offensive-ai-security`](Skills/ai/offensive-ai-security/SKILL.md) | AI/ML security — prompt injection, jailbreaking, RAG poisoning, model extraction |
 
 ### Utility
 
@@ -377,28 +335,28 @@ Paste the contents of a `SKILL.md` into a Project's system prompt or prepend to 
 
 | Skill | Description |
 |---|---|
-| [`offensive-fast-checking`](Skills/utility/offensive-fast-checking/SKILL.md) | Fast triage checklist — quick-win identification |
-| [`offensive-reporting`](Skills/utility/offensive-reporting/SKILL.md) | Pro pentest reporting — CVSS, evidence, exec summary, retest |
+| [`offensive-fast-checking`](Skills/utility/offensive-fast-checking/SKILL.md) | Fast triage — quick-win identification checklists |
+| [`offensive-reporting`](Skills/utility/offensive-reporting/SKILL.md) | Professional reporting — CVSS scoring, evidence standards, executive summaries |
 
 ---
 
 ## Roadmap
 
-The library is being expanded in seven phases. Track progress in [CHANGELOG.md](CHANGELOG.md).
+The library is being expanded across multiple phases. See [CHANGELOG.md](CHANGELOG.md) for release history.
 
-| Phase | Category | New Skills | Status |
+| Phase | Focus | Skills | Status |
 |---|---|---:|---|
-| 1 | Internal AD/Windows (rename `active-directory/` → `internal/`) | +16 | Planned |
-| 2 | Cloud Identity (Entra/AAD, ADFS, Okta, M365) | +10 | Planned |
-| 3 | Wireless split (WPA2/3, EAP, BLE, Zigbee, Z-Wave, LoRa, sub-GHz) | +12 | **Done** |
-| 4 | IoT split (UART/JTAG, flash, fault injection, RTOS, ICS) | +10 | Planned |
-| 5 | Web Basics (recon, auth bypass, access control, CSRF, headers, CORS, cache, clickjack) | +8 | Planned |
-| 6 | Web Advanced (proto pollution, SAML, OIDC, WebSocket, gRPC, postMessage, SSI/ESI, CSTI) | +10 | Planned |
-| 7 | Polish (README, LICENSE, manifest, install) | — | **Done** |
-| 8 | New categories (API, container, CI/CD, crypto, privesc, post-exploitation, forensics/C2, supply chain, social engineering, network) | +20 | **Done** |
-| 9 | Deep rewrites (deserialization, GraphQL, advanced red team, SSTI) | — | **Done** |
+| 1 | Internal AD/Windows — split into focused skills | +16 | Planned |
+| 2 | Cloud Identity — Entra, ADFS, Okta, M365 | +10 | Planned |
+| 3 | Wireless — WPA2/3, EAP, BLE, Zigbee, Z-Wave, LoRa, sub-GHz | +12 | Complete |
+| 4 | IoT — UART/JTAG, flash extraction, fault injection, RTOS, ICS | +10 | Planned |
+| 5 | Web Fundamentals — recon, auth bypass, access control, CSRF, CORS | +8 | Planned |
+| 6 | Web Advanced — proto pollution, SAML, OIDC, WebSocket, SSI/ESI | +10 | Planned |
+| 7 | Documentation and tooling polish | — | Complete |
+| 8 | New categories — 10 new domains with 20 skills | +20 | Complete |
+| 9 | Deep rewrites — deserialization, GraphQL, advanced red team, SSTI | — | Complete |
 
-End state: ~130 skills across 23+ categories.
+Target: ~130 skills across 23+ categories.
 
 ---
 
@@ -412,32 +370,16 @@ Contributions welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the skill temp
 
 ## Acknowledgements
 
-- **Author:** Kai Aizen (SnailSploit) — [snailsploit.com](https://snailsploit.com)
-- **Original Checklists:** [Sahar Shlichov](https://github.com/sahar042/offensive-checklist) — the offensive checklist collection many of these skills are based on.
-- **Community:** PRs and feedback that keep the library current with the threat landscape.
+- **Author:** [Kai Aizen](https://snailsploit.com) (SnailSploit) — GenAI security research
+- **Original Checklists:** [Sahar Shlichov](https://github.com/sahar042/offensive-checklist) — the offensive checklist collection that many of these skills build on
+- **Community:** Pull requests and feedback that keep the library aligned with the evolving threat landscape
 
 ---
 
 <div align="center">
 
-> *"Give Claude the right skill and it stops being a chatbot. It becomes an operator."*
+*Give Claude the right skill and it stops being a chatbot — it becomes an operator.*
+
+[snailsploit.com](https://snailsploit.com) &bull; [GitHub](https://github.com/SnailSploit) &bull; [Research](https://snailsploit.com/research) &bull; [X](https://x.com/SnailSploit)
 
 </div>
-
-<!-- snailsploit-backlink:start -->
-
----
-
-## 📚 Documentation & Author
-
-This project's full writeup, methodology, and related research lives at:
-
-**[https://snailsploit.com/claude-red](https://snailsploit.com/claude-red)**
-
-Created by **Kai Aizen** — independent offensive security researcher.
-
-[snailsploit.com](https://snailsploit.com) · [Research](https://snailsploit.com/research) · [Frameworks](https://snailsploit.com/frameworks) · [GitHub](https://github.com/SnailSploit) · [LinkedIn](https://linkedin.com/in/kaiaizen) · [ResearchGate](https://www.researchgate.net/profile/Kai-Aizen-2) · [X/Twitter](https://x.com/SnailSploit)
-
-> *Same attack. Different substrate.*
-
-<!-- snailsploit-backlink:end -->


### PR DESCRIPTION
## Summary

- Rename "What is this" section to "Overview"
- Fix wireless skill count (13 → 14) to match the manifest
- Consolidate redundant author/backlink sections into a single compact footer
- Replace verbose Table of Contents with inline dot-separated nav bar
- Standardize all 78 skill descriptions for consistent tone and formatting
- Remove informal "(expanding)" markers from the category table
- Clean up roadmap status labels ("Done" → "Complete")
- Tighten closing quote and social links into one centered block

## Test plan

- [ ] Verify all 78 skill links resolve correctly
- [ ] Confirm category table counts match `claude-skills.json` manifest
- [ ] Check markdown renders correctly on GitHub (tables, badges, nav bar)
- [ ] Verify no broken anchor links in navigation

---
_Generated by [Claude Code](https://claude.ai/code/session_01TGTU7GfpARyCd5Z4cdxkuN)_